### PR TITLE
EPS-814: Wordpress 6.7 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.4
 Tags: beaver builder, page builder plugin, expandable, expand, row expand, row
 Stable tag: 1.1.3
-Tested up to: 6.6
+Tested up to: 6.7
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This pull request includes a small change to the `readme.txt` file. The change updates the version of WordPress the plugin has been tested up to.

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7): Updated the "Tested up to" version from 6.6 to 6.7.