### PR TITLE
Fix: CSS color fields incorrectly prepend # to rgb/hsl values

### DIFF
--- a/expandable-row-for-beaver-builder.php
+++ b/expandable-row-for-beaver-builder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Expandable Row for Beaver Builder
  * Plugin URI: https://pratikchaskar.com
  * Description: Toggle any row with this plugin in Beaver Builder
- * Version: 1.1.4
+ * Version: 1.1.5
  * Author: Pratik Chaskar
  * Author URI: https://pratikchaskar.com
  * License: GNU General Public License v3.0

--- a/expandable-row/css/row-css.php
+++ b/expandable-row/css/row-css.php
@@ -1,9 +1,6 @@
 <?php
 if ( ! function_exists( 'bber_format_color' ) ) {
-	function bber_format_color( $color, $fallback = 'inherit' ) {
-		if ( $color === '' || $color === null ) {
-			return $fallback;
-		}
+	function bber_format_color( $color ) {
 		// If already has a recognized prefix, output as-is
 		if ( $color[0] === '#' || 0 === strncasecmp( $color, 'rgb', 3 ) || 0 === strncasecmp( $color, 'hsl', 3 ) ) {
 			return esc_attr( $color );
@@ -16,7 +13,7 @@ if ( ! function_exists( 'bber_format_color' ) ) {
 
 	/* Icon Padding */
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-icon {
-		color: <?php echo bber_format_color( $row->settings->er_bc_icon_color, 'inherit' ); ?>;
+		color: <?php echo ( $row->settings->er_bc_icon_color != '' ) ? bber_format_color( $row->settings->er_bc_icon_color ) : 'inherit' ?>;
 		font-size: <?php echo ( $row->settings->er_icon_size != '' ) ? esc_attr( $row->settings->er_icon_size ) . 'px' : 'inherit' ?>;
 		vertical-align: middle;
 		padding: 0 10px;
@@ -27,7 +24,7 @@ if ( ! function_exists( 'bber_format_color' ) ) {
 		transition: all 0.3s ease-out;
 	}
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-expanded .bber-icon {
-		color: <?php echo bber_format_color( $row->settings->er_ac_icon_color, 'inherit' ); ?>;
+		color: <?php echo ( $row->settings->er_ac_icon_color != '' ) ? bber_format_color( $row->settings->er_ac_icon_color ) : 'inherit' ?>;
 	}
 
 	/* Image Padding */
@@ -35,10 +32,10 @@ if ( ! function_exists( 'bber_format_color' ) ) {
 		padding: 0 10px;
 	}
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bb-er-row:hover .bber-icon {
-		color: <?php echo bber_format_color( $row->settings->er_bc_icon_hcolor, 'inherit' ); ?>;
+		color: <?php echo ( $row->settings->er_bc_icon_hcolor != '' ) ? bber_format_color( $row->settings->er_bc_icon_hcolor ) : 'inherit' ?>;
 	}
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-expanded:hover .bber-icon {
-		color: <?php echo bber_format_color( $row->settings->er_ac_icon_hcolor, 'inherit' ); ?>;
+		color: <?php echo ( $row->settings->er_ac_icon_hcolor != '' ) ? bber_format_color( $row->settings->er_ac_icon_hcolor ) : 'inherit' ?>;
 	}
 
 	<?php if ( ! FLBuilderModel::is_builder_active() ): ?>
@@ -51,9 +48,9 @@ if ( ! function_exists( 'bber_format_color' ) ) {
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bb-er-row {
 		width:100%;
 		cursor: pointer;
-		color: <?php echo bber_format_color( $row->settings->er_bc_title_color, '#000' ); ?>;
+		color: <?php echo ( $row->settings->er_bc_title_color != '' ) ? bber_format_color( $row->settings->er_bc_title_color ) : '#000' ?>;
 		<?php if( $row->settings->er_bg_type == 'color'): ?>
-			background-color: <?php echo bber_format_color( $row->settings->er_bc_bg_color, '#c7c7c7' ); ?>;
+			background-color: <?php echo ( $row->settings->er_bc_bg_color != '' ) ? bber_format_color( $row->settings->er_bc_bg_color ) : '#c7c7c7' ?>;
 		<?php elseif ($row->settings->er_bg_type == 'image' ): ?>
 			background-image: url(<?php echo isset( $row->settings->er_bc_bg_image_src ) ? esc_attr( $row->settings->er_bc_bg_image_src ) : null ; ?>);
 		<?php endif ?>
@@ -79,9 +76,9 @@ if ( ! function_exists( 'bber_format_color' ) ) {
 
 	/* After click expand */
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-expanded {
-		color: <?php echo bber_format_color( $row->settings->er_ac_title_color, 'inherit' ); ?>;
+		color: <?php echo ( $row->settings->er_ac_title_color != '' ) ? bber_format_color( $row->settings->er_ac_title_color ) : 'inherit' ?>;
 		<?php if ( $row->settings->er_bg_type == 'color' ): ?>
-			background-color: <?php echo bber_format_color( $row->settings->er_ac_bg_color, '#c7c7c7' ); ?>;
+			background-color: <?php echo ( $row->settings->er_ac_bg_color != '' ) ? bber_format_color( $row->settings->er_ac_bg_color ) : '#c7c7c7' ?>;
 		<?php elseif ( $row->settings->er_bg_type == 'image' ): ?>
 			background-image: url(<?php echo isset( $row->settings->er_ac_bg_image_src ) ? esc_attr( $row->settings->er_ac_bg_image_src ) : null ; ?>);
 		<?php endif ?>
@@ -90,17 +87,17 @@ if ( ! function_exists( 'bber_format_color' ) ) {
 
 	/* Expandable row hover */
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bb-er-row:hover {
-		color: <?php echo bber_format_color( $row->settings->er_bc_title_hcolor, 'inherit' ); ?>;
+		color: <?php echo ( $row->settings->er_bc_title_hcolor != '' ) ? bber_format_color( $row->settings->er_bc_title_hcolor ) : 'inherit' ?>;
 		<?php if ( $row->settings->er_bg_type == 'color' ): ?>
-			background-color: <?php echo bber_format_color( $row->settings->er_bc_bg_hcolor, 'inherit' ); ?>;
+			background-color: <?php echo ( $row->settings->er_bc_bg_hcolor != '' ) ? bber_format_color( $row->settings->er_bc_bg_hcolor ) : 'inherit' ?>;
 		<?php endif ?>
 	}
 
 	/* After click hover */
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-expanded:hover {
-		color: <?php echo bber_format_color( $row->settings->er_ac_title_hcolor, 'inherit' ); ?>;
+		color: <?php echo ( $row->settings->er_ac_title_hcolor != '' ) ? bber_format_color( $row->settings->er_ac_title_hcolor ) : 'inherit' ?>;
 		<?php if ( $row->settings->er_bg_type == 'color' ): ?>
-			background-color: <?php echo bber_format_color( $row->settings->er_ac_bg_hcolor, '#c7c7c7' ); ?>;
+			background-color: <?php echo ( $row->settings->er_ac_bg_hcolor != '' ) ? bber_format_color( $row->settings->er_ac_bg_hcolor ) : '#c7c7c7' ?>;
 		<?php endif ?>
 	}
 

--- a/expandable-row/css/row-css.php
+++ b/expandable-row/css/row-css.php
@@ -1,8 +1,22 @@
+<?php
+if ( ! function_exists( 'bber_format_color' ) ) {
+	function bber_format_color( $color, $fallback = 'inherit' ) {
+		if ( $color === '' || $color === null ) {
+			return $fallback;
+		}
+		// If already has a recognized prefix, output as-is
+		if ( $color[0] === '#' || 0 === strncasecmp( $color, 'rgb', 3 ) || 0 === strncasecmp( $color, 'hsl', 3 ) ) {
+			return esc_attr( $color );
+		}
+		return '#' . esc_attr( $color );
+	}
+}
+?>
 <?php if ( $row->settings->is_enable == 'yes' ): ?>
 
 	/* Icon Padding */
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-icon {
-		color: <?php echo ( $row->settings->er_bc_icon_color != '' ) ? '#' . esc_attr( $row->settings->er_bc_icon_color ) : 'inherit' ?>;
+		color: <?php echo bber_format_color( $row->settings->er_bc_icon_color, 'inherit' ); ?>;
 		font-size: <?php echo ( $row->settings->er_icon_size != '' ) ? esc_attr( $row->settings->er_icon_size ) . 'px' : 'inherit' ?>;
 		vertical-align: middle;
 		padding: 0 10px;
@@ -13,8 +27,7 @@
 		transition: all 0.3s ease-out;
 	}
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-expanded .bber-icon {
-		color: <?php echo ( $row->settings->er_ac_icon_color != '' ) ? '#' . esc_attr( $row->settings->er_ac_icon_color ) : 'inherit' 
-		?>;
+		color: <?php echo bber_format_color( $row->settings->er_ac_icon_color, 'inherit' ); ?>;
 	}
 
 	/* Image Padding */
@@ -22,10 +35,10 @@
 		padding: 0 10px;
 	}
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bb-er-row:hover .bber-icon {
-		color: <?php echo ( $row->settings->er_bc_icon_hcolor != '' ) ? '#' . esc_attr( $row->settings->er_bc_icon_hcolor ) : 'inherit' ?>;
+		color: <?php echo bber_format_color( $row->settings->er_bc_icon_hcolor, 'inherit' ); ?>;
 	}
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-expanded:hover .bber-icon {
-		color: <?php echo ( $row->settings->er_ac_icon_hcolor != '' ) ? '#' . esc_attr( $row->settings->er_ac_icon_hcolor ) : 'inherit' ?>;
+		color: <?php echo bber_format_color( $row->settings->er_ac_icon_hcolor, 'inherit' ); ?>;
 	}
 
 	<?php if ( ! FLBuilderModel::is_builder_active() ): ?>
@@ -38,9 +51,9 @@
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bb-er-row {
 		width:100%;
 		cursor: pointer;
-		color: #<?php echo ( $row->settings->er_bc_title_color != '' ) ? esc_attr( $row->settings->er_bc_title_color ) : '000' ; ?>;
+		color: <?php echo bber_format_color( $row->settings->er_bc_title_color, '#000' ); ?>;
 		<?php if( $row->settings->er_bg_type == 'color'): ?>
-			background-color:#<?php echo ( $row->settings->er_bc_bg_color != '' ) ? esc_attr( $row->settings->er_bc_bg_color ) : 'c7c7c7' ; ?>;
+			background-color: <?php echo bber_format_color( $row->settings->er_bc_bg_color, '#c7c7c7' ); ?>;
 		<?php elseif ($row->settings->er_bg_type == 'image' ): ?>
 			background-image: url(<?php echo isset( $row->settings->er_bc_bg_image_src ) ? esc_attr( $row->settings->er_bc_bg_image_src ) : null ; ?>);
 		<?php endif ?>
@@ -66,9 +79,9 @@
 
 	/* After click expand */
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-expanded {
-		color: <?php echo ( $row->settings->er_ac_title_color != '' ) ? '#' . esc_attr( $row->settings->er_ac_title_color ) : 'inherit' ; ?>;
+		color: <?php echo bber_format_color( $row->settings->er_ac_title_color, 'inherit' ); ?>;
 		<?php if ( $row->settings->er_bg_type == 'color' ): ?>
-			background-color: <?php echo ( $row->settings->er_ac_bg_color != '' ) ? '#' . esc_attr( $row->settings->er_ac_bg_color ) : '#c7c7c7' ; ?>;
+			background-color: <?php echo bber_format_color( $row->settings->er_ac_bg_color, '#c7c7c7' ); ?>;
 		<?php elseif ( $row->settings->er_bg_type == 'image' ): ?>
 			background-image: url(<?php echo isset( $row->settings->er_ac_bg_image_src ) ? esc_attr( $row->settings->er_ac_bg_image_src ) : null ; ?>);
 		<?php endif ?>
@@ -77,18 +90,18 @@
 
 	/* Expandable row hover */
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bb-er-row:hover {
-		color: <?php echo ( $row->settings->er_bc_title_hcolor != '' ) ? '#' . esc_attr( $row->settings->er_bc_title_hcolor ) : 'inherit' ; ?>;
+		color: <?php echo bber_format_color( $row->settings->er_bc_title_hcolor, 'inherit' ); ?>;
 		<?php if ( $row->settings->er_bg_type == 'color' ): ?>
-			background-color: <?php echo ( $row->settings->er_bc_bg_hcolor != '' ) ? '#' . esc_attr( $row->settings->er_bc_bg_hcolor ) : 'inherit' ; ?>;
+			background-color: <?php echo bber_format_color( $row->settings->er_bc_bg_hcolor, 'inherit' ); ?>;
 		<?php endif ?>
 	}
 
 	/* After click hover */
 	.fl-node-<?php echo esc_attr( $row->node ); ?> .bber-expanded:hover {
-		color: <?php echo ( $row->settings->er_ac_title_hcolor != '' ) ? '#' . esc_attr( $row->settings->er_ac_title_hcolor ) : 'inherit' ; ?>;
+		color: <?php echo bber_format_color( $row->settings->er_ac_title_hcolor, 'inherit' ); ?>;
 		<?php if ( $row->settings->er_bg_type == 'color' ): ?>
-			background-color: <?php echo ( $row->settings->er_ac_bg_hcolor != '' ) ? '#' . esc_attr( $row->settings->er_ac_bg_hcolor ) : '#c7c7c7' ; ?>;
-		<?php endif ?>	
+			background-color: <?php echo bber_format_color( $row->settings->er_ac_bg_hcolor, '#c7c7c7' ); ?>;
+		<?php endif ?>
 	}
 
 	/* Image icon size */

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Requires at least: 4.4
 Tags: beaver builder, page builder plugin, expandable, expand, row expand
 Stable tag: 1.1.4
-Tested up to: 6.9
+Tested up to: 7.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pratikchaskar
 Requires at least: 4.4
 Tags: beaver builder, page builder plugin, expandable, expand, row expand
-Stable tag: 1.1.4
+Stable tag: 1.1.5
 Tested up to: 7.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -24,8 +24,12 @@ Simple Expandable Row for Beaver Builder. This plugin toggles any row in Beaver 
 4. Find this plugin option in `Row Settings` of `Page Builder` in `Expandable Row` tab.
 
 == Changelog ==
+= 1.1.5 =
+- Improvement: Added compatibility to WordPress 7.0
+- Fixed: Resolved an issue where row color settings using RGB or HSL values generated invalid CSS due to an extra # prefix.
+
 = 1.1.4 =
-Updated readme file.
+- Updated readme file.
 
 = 1.1.3 =
 - Improvement: Improved codebase for improved security.


### PR DESCRIPTION
## Summary

- Adds a `bber_format_color()` helper function in `row-css.php` that detects the color format and only prepends `#` for plain hex values
- Replaces all 12 hardcoded color output patterns throughout the file to use this helper
- Handles `rgb()`, `rgba()`, `hsl()`, and `hsla()` values correctly, as well as colors already prefixed with `#`
- Per review feedback: empty/fallback check moved to each call site so the helper is only invoked when a value exists

Fixes #32
Supersedes #33 (re-raised with signed commits)

## Root Cause

All color fields were unconditionally prefixed with `#` — either embedded directly in the template string (`background-color:#<?php echo ...`) or concatenated in PHP (`'#' . esc_attr($color)`). This works for plain hex values but produces invalid CSS like `background-color: #rgb(255, 0, 0)` when a theme's color picker returns an RGB value.

## Test plan

- [ ] Set a background color using an RGB value (e.g. `rgb(255, 0, 0)`) via the color picker — verify the generated CSS is `background-color: rgb(255, 0, 0)`
- [ ] Set a background color using a plain hex value (e.g. `ff0000`) — verify the generated CSS is `background-color: #ff0000`
- [ ] Set a background color using a hex value with `#` already included — verify no double `#` appears
- [ ] Verify hover and active state colors render correctly for all the above formats
- [ ] Test with icon colors and title colors in the same formats